### PR TITLE
Fixes broken Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ $ open http://localhost:9000
 ### Run the application on heroku
 
 - Install the [heroku toolbelt](https://devcenter.heroku.com/articles/getting-started-with-scala#set-up)
-- ``` 
+- Run following commands:
+``` 
 $ heroku login
 $ heroku create
 $ git push heroku master


### PR DESCRIPTION
Heroku commands and Features section were messed up, because you can't have multi-line code block inside the list.
